### PR TITLE
Add Config Limits

### DIFF
--- a/analog-alarm.js
+++ b/analog-alarm.js
@@ -50,14 +50,19 @@ module.exports = function(RED) {
                 var currentValue = parseFloat(msg.payload);
 
                 var alarmStatus = previousStatus;
+                var limitStatus = "";
                 if (currentValue >= hihiLimit) {
                     alarmStatus = 'HiHi';
+                    limitStatus = hihiLimit;
                 } else if (currentValue < hihiLimit - deadband && currentValue >= hiLimit) {
                     alarmStatus = 'Hi';
+                    limitStatus = hiLimit;
                 } else if (currentValue < loLimit) {
                     alarmStatus = 'Lo';
+                    limitStatus = loLimit;
                 } else if (currentValue <= loloLimit) {
                     alarmStatus = 'LoLo';
+                    limitStatus = loloLimit;
                 } else if (currentValue < hiLimit && currentValue > loLimit) {
                     alarmStatus = 'Normal';
                 }
@@ -75,6 +80,7 @@ module.exports = function(RED) {
                         area: areaName,
                         description: alarmDescription,
                         value: currentValue,
+                        limitConfig: limitStatus,
                         status: alarmStatus
                     };
 


### PR DESCRIPTION
Thinking that the output object can be used in a system external to Node-RED, in addition to sending the alarm, I think it is interesting to send the configured limit, that is, if the HH limit was added with the value of 99 and the limit is configured as 90 , it would be interesting to send the configured value.